### PR TITLE
Call updateCount function initially

### DIFF
--- a/src/jquery.freeChars.js
+++ b/src/jquery.freeChars.js
@@ -26,6 +26,7 @@
     if( config.maxLength ){
       this.updateCount = $.proxy(this.updateCount, this)
       this.$el.on('keyup change cut paste drop', this.updateCount)
+      this.updateCount.call();
     }
   }
 


### PR DESCRIPTION
It is needed to update counter if textarea already has a value. For
example, if you are editing something.
